### PR TITLE
[FIX] Fix wrong paths for FAQ images

### DIFF
--- a/pages/faq/llm-not-using-my-docs.mdx
+++ b/pages/faq/llm-not-using-my-docs.mdx
@@ -3,13 +3,13 @@ title: "Why does the LLM not use my documents"
 description: "We get this question many times a week"
 ---
 
-import { Callout } from 'nextra/components'
-import Image from 'next/image'
+import { Callout } from "nextra/components";
+import Image from "next/image";
 
 <Image
-  src="/images/guides-and-faq/llm-not-using-my-docs/thumbnail.png" 
-  height={1080} 
-  width={1920} 
+  src="/images/faq/llm-not-using-my-docs/thumbnail.png"
+  height={1080}
+  width={1920}
   quality={100}
   alt="AnythingLLM -- Why does the LLM not use my documents?"
 />
@@ -18,43 +18,37 @@ import Image from 'next/image'
 
 <Callout type="info" emoji="️💡">
   **Tip:**
-    This page is a deep dive on how or why your LLM is not using your documents when asking questions. 
-    
+    This page is a deep dive on how or why your LLM is not using your documents when asking questions.
+
     Luckily, it's simple to solve for, actually! These ideas extend beyond just AnythingLLM.
+
 </Callout>
 
-
-We get this question many times a week, where someone is confused, or even upset the LLM does not appear to "just know everything" about the documents that are embedded into a workspace. 
+We get this question many times a week, where someone is confused, or even upset the LLM does not appear to "just know everything" about the documents that are embedded into a workspace.
 
 So to understand why this occurs we first need to clear up some confusion on how RAG (retrieval augmented generation) works inside of AnythingLLM.
 
 This will not be deeply technical, but once you read this you will be an expert on how traditional RAG works.
 
-
 ## LLMs are not omnipotent
 
-Unfortunately, LLMs are not yet sentient and so it is vastly unrealistic with even the most powerful models for the model you are using to just "know what you mean". 
+Unfortunately, LLMs are not yet sentient and so it is vastly unrealistic with even the most powerful models for the model you are using to just "know what you mean".
 
 That being said there are a ton of factors and moving parts that can impact the output and salience of an LLM and even to complicate things further, each factor can impact your output depending on what your specific use case is!
 
-
 ## LLMs do not introspect
 
-In AnythingLLM, we do not read your entire filesystem and then report that to the LLM, as it would waste tokens 99% of the time. 
+In AnythingLLM, we do not read your entire filesystem and then report that to the LLM, as it would waste tokens 99% of the time.
 
 Instead, your query is processed against your vector database of document text and we get back 4-6 text chunks from the documents that are deemed "relevant" to your prompt.
 
-
 For example, let's say you have a workspace of hundreds of recipes, don't ask "Get me the title of the 3 high-calorie meals". This LLM will outright refuse this! but why?
 
-
-When you use RAG for document chatbots your entire document text cannot possibly fit in most LLM context windows. Splitting the document into chunks of text and then saving those chunks in a vector database makes it easier to "augment" an LLM's base knowledge with snippets of relevant information based on your query. 
+When you use RAG for document chatbots your entire document text cannot possibly fit in most LLM context windows. Splitting the document into chunks of text and then saving those chunks in a vector database makes it easier to "augment" an LLM's base knowledge with snippets of relevant information based on your query.
 
 Your entire document set is not "embedded" into the model. It has no idea what is in each document nor where those documents even are.
 
-
 If this is what you want, you are thinking of agents, which are coming to AnythingLLM soon.
-
 
 ## So how does AnythingLLM work?
 
@@ -64,9 +58,9 @@ Let's think of AnythingLLM as a framework or pipeline.
 
 2. You upload a document, this makes it possible to "Move into a workspace" or "embed" the document. Uploading takes your document and turns it into text - that's it.
 
-3. You "Move document to workspace". This takes the text from step 2 and chunks it into more digestable sections. Those chunks are then sent to your embedder model and turned into a list of numbers, called a vector. 
+3. You "Move document to workspace". This takes the text from step 2 and chunks it into more digestable sections. Those chunks are then sent to your embedder model and turned into a list of numbers, called a vector.
 
-4. This string of numbers is saved to your vector database and is fundamentally how RAG works.  There is no guarantee that relevant text stays together during this step!  This is an area of active research.
+4. This string of numbers is saved to your vector database and is fundamentally how RAG works. There is no guarantee that relevant text stays together during this step! This is an area of active research.
 
 5. You type a question into the chatbox and press send.
 
@@ -74,17 +68,16 @@ Let's think of AnythingLLM as a framework or pipeline.
 
 7. The vector database then calculates the "nearest" chunk-vector. AnythingLLM filters any "low-score" text chunks (you can modify this). Each vector has the original text it was derived from attached to it.
 
-
 <Callout type="warning" emoji="️⚠️">
   **IMPORTANT!**
 
-    This is not a purely semantic process so the vector database would not "know what you mean". 
-    
-    It's a mathematical process using the "Cosine Distance" formula. 
-    
-    However, here is where the embedder model used and other AnythingLLM settings can make the most difference. Read more in the next section.
-</Callout>
+    This is not a purely semantic process so the vector database would not "know what you mean".
 
+    It's a mathematical process using the "Cosine Distance" formula.
+
+    However, here is where the embedder model used and other AnythingLLM settings can make the most difference. Read more in the next section.
+
+</Callout>
 
 8. Whatever chunks deemed valid are then passed to the LLM as the original text. Those texts are then appended to the LLM is its "System message". This context is inserted below your system prompt for that workspace.
 
@@ -92,40 +85,35 @@ Let's think of AnythingLLM as a framework or pipeline.
 
 Done.
 
-
 ## How can I make retrieval better then?
 
-AnythingLLM exposes many many options to tune your workspace to better fit with your selection of LLM, embedder, and vector database. 
+AnythingLLM exposes many many options to tune your workspace to better fit with your selection of LLM, embedder, and vector database.
 
 The workspace options are the easiest to mess with and you should start there first. AnythingLLM makes some default assumptions in each workspace. These work for some but certainly not all use cases.
 
 You can find these settings by hovering over a workspace and clicking the "Gear" icon.
 
 <Image
-  src="/images/guides-and-faq/llm-not-using-my-docs/workspace-settings-icon.png" 
-  height={1080} 
-  width={1920} 
+  src="/images/faq/llm-not-using-my-docs/workspace-settings-icon.png"
+  height={1080}
+  width={1920}
   quality={100}
   alt="AnythingLLM Workspace settings"
 />
-
 
 ### Chat Settings > Prompt
 
 This is the system prompt for your workspace. This is the "rule set" your workspace will follow and how it will ultimately respond to queries. Here you can define it to respond in a certain programming language, maybe a specific language, or anything else. Just define it here.
 
-
 ### Chat Settings > LLM Temperature
 
 This determines how "inventive" the LLM is with responses. This varies from model to model. Know that the higher the number the more "random" a response will be. Lower is more short, terse, and more "factual".
-
 
 ### Vector Database Settings > Max Context Snippets
 
 This is a very critical item during the "retrieval" part of RAG. This determines "How many relevant snippets of text do I want to send to the LLM". Intuitively you may think "Well, I want all of them", but that is not possible since there is an upper limit to how many tokens each model can process. This window, called the context window, is shared with the system prompt, context, query, and history.
 
 AnythingLLM will trim data from the context if you are going to overflow the model - which will crash it. So it's best to keep this value anywhere from 4-6 for the majority of models. If using a large-context model like Claude-3, you can go higher but beware that too much "noise" in the context may mislead the LLM in response generation.
-
 
 ### Vector Database Settings > Document similarity threshold
 
@@ -140,7 +128,6 @@ If you are getting hallucinations or bad LLM responses, you should set this to N
 - More vectors = more possible noise, and matches that are actually irrelevant.
 - Your query: This is what the matching vector is based on. Vague queries get vague results.
 
-
 ## Document Pinning
 
 As a last resort, if the above settings do not seem to change anything for you - then document pinning may be a good solution.
@@ -150,9 +137,9 @@ Document Pinning is where we do a full-text insertion of the document into the c
 Document Pinning should be reserved for documents that can either fully fit in the context window or are extremely critical for the use-case of that workspace.
 
 <Image
-  src="/images/guides-and-faq/llm-not-using-my-docs/document-pinning.png" 
-  height={1080} 
-  width={1920} 
+  src="/images/faq/llm-not-using-my-docs/document-pinning.png"
+  height={1080}
+  width={1920}
   quality={100}
   alt="AnythingLLM Document Pinning"
 />


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #23 


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the documentation site. -->

- `llm-not-using-my-docs` page image paths updated to point to the correct images

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->



### Validations

<!-- All of the applicable items should be checked. -->

- [x] Ensured updated documentation pass spell check
- [x] Updated or added relevant links as needed
- [x] Reviewed the changes for clarity and accuracy
- [x] Successfully ran the code locally without encountering errors
