### PR TITLE
Update storage.mdx

### DIFF
--- a/pages/installation-desktop/storage.mdx
+++ b/pages/installation-desktop/storage.mdx
@@ -14,7 +14,7 @@ On Mac:
 `/Users/<usr>/Library/Application Support/anythingllm-desktop/storage`
 
 On Linux:
-`/Users/<usr>/.config/anythingllm-desktop/storage/`
+`~/.config/anythingllm-desktop/storage/`
 
 On Windows:
 `C:\Users\<usr>\AppData\Roaming\anythingllm-desktop\storage`


### PR DESCRIPTION
Correct the storage path on Linux to reference ~.

### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #xxx


### What is in this change?

The documented storage path for Linux was incorrect / looked to be copy / pasted from the line for OSX. 


### Additional Information

I'm not an OSX user but I have to wonder if referencing `~` might be correct there as well. 


### Validations

<!-- All of the applicable items should be checked. -->

- [x] Ensured updated documentation pass spell check
- [x] Updated or added relevant links as needed
- [x] Reviewed the changes for clarity and accuracy
- [x] Successfully ran the code locally without encountering errors
