### PR TITLE
Fix Dev Startup Errors 

### DIFF
--- a/components/card.tsx
+++ b/components/card.tsx
@@ -1,0 +1,17 @@
+import { Cards } from "nextra/components";
+
+type CardProps = {
+  image?: boolean;
+  arrow?: boolean;
+  title: string;
+  children: React.ReactNode;
+  icon: React.ReactNode;
+  href: string;
+};
+export const Card: React.FC<CardProps> = ({
+  image = true,
+  arrow = true,
+  ...props
+}) => {
+  return <Cards.Card image={image} arrow={arrow} {...props} />;
+};

--- a/pages/_meta.json
+++ b/pages/_meta.json
@@ -317,7 +317,7 @@
     "display": "hidden"
   },
   "community-hub": {
-    "type": "hidden"
+    "display": "hidden"
   },
   "support": {
     "title": "Support",

--- a/pages/agent-flows/blocks/_meta.json
+++ b/pages/agent-flows/blocks/_meta.json
@@ -1,8 +1,8 @@
 {
   "intro": {
     "title": "Overview",
+    "display": "hidden",
     "theme": {
-      "hidden": true,
       "breadcrumb": true,
       "footer": true,
       "pagination": true,
@@ -11,8 +11,8 @@
   },
   "default-blocks": {
     "title": "Default Blocks",
+    "display": "hidden",
     "theme": {
-      "hidden": true,
       "breadcrumb": true,
       "footer": true,
       "pagination": true,

--- a/pages/agent-flows/blocks/intro.mdx
+++ b/pages/agent-flows/blocks/intro.mdx
@@ -26,15 +26,6 @@ Learn about the blocks that are available to you in the flow editor. Keep in min
 <Card title="Read File" href="/agent-flows/blocks/read-file" style={{ margin: "1rem" }} />
 <Card title="Write File" href="/agent-flows/blocks/write-file" style={{ margin: "1rem" }} />
 
-export const Card = Object.assign(
-  // Copy card component and add default props
-  Cards.Card.bind(),
-  {
-    displayName: "Card",
-    defaultProps: {
-      image: true,
-      arrow: true,
-      target: "_self",
-    },
-  }
-);
+export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
+  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
+};

--- a/pages/agent-flows/blocks/intro.mdx
+++ b/pages/agent-flows/blocks/intro.mdx
@@ -4,6 +4,7 @@ description: "Learn about the blocks that are available to you in the flow edito
 ---
 
 import { Callout, Cards } from "nextra/components";
+import { Card } from "../../../components/card";
 
 <Callout type="info" emoji="💡">
   If you expect to use a block in your flow, but it is not available - you are probably using the wrong version of AnythingLLM.
@@ -26,6 +27,3 @@ Learn about the blocks that are available to you in the flow editor. Keep in min
 <Card title="Read File" href="/agent-flows/blocks/read-file" style={{ margin: "1rem" }} />
 <Card title="Write File" href="/agent-flows/blocks/write-file" style={{ margin: "1rem" }} />
 
-export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
-  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
-};

--- a/pages/agent/overview.mdx
+++ b/pages/agent/overview.mdx
@@ -5,6 +5,7 @@ description: "What are AI Agents in AnythingLLM and how to use them?"
 
 import { Cards, Callout } from "nextra/components";
 import Image from "next/image";
+import { Card } from "../../components/card";
 
 <Image
   src="/images/guides/ai-agents/header-image.png"
@@ -44,9 +45,6 @@ All agents share the same tools across workspaces, but operate within the worksp
   </Card>
 </Cards>
 
-export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
-  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
-};
 
 <style global jsx>{`
   img {

--- a/pages/agent/overview.mdx
+++ b/pages/agent/overview.mdx
@@ -44,18 +44,9 @@ All agents share the same tools across workspaces, but operate within the worksp
   </Card>
 </Cards>
 
-export const Card = Object.assign(
-  // Copy card component and add default props
-  Cards.Card.bind(),
-  {
-    displayName: "Card",
-    defaultProps: {
-      image: true,
-      arrow: true,
-      target: "_self",
-    },
-  }
-);
+export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
+  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
+};
 
 <style global jsx>{`
   img {

--- a/pages/agent/setup.mdx
+++ b/pages/agent/setup.mdx
@@ -124,8 +124,8 @@ If you want to learn how to use AI Agents then you can read our [AI Agent Guide]
   height="450"
   src="https://www.youtube.com/embed/4UFrVvy7VlA?si=TtWQ-Sg5fxytVsKI"
   title="YouTube video player"
-  frameborder="0"
+  frameBorder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-  referrerpolicy="strict-origin-when-cross-origin"
-  allowfullscreen
+  referrerPolicy="strict-origin-when-cross-origin"
+  allowFullScreen
 ></iframe>

--- a/pages/beta-preview/active-features/computer-use.mdx
+++ b/pages/beta-preview/active-features/computer-use.mdx
@@ -5,14 +5,9 @@ description: "Enable an AI to autonomously use your computer to complete tasks"
 
 import { Callout, Cards } from "nextra/components";
 import Image from "next/image";
-export const Card = Object.assign(Cards.Card.bind(), {
-  displayName: "Card",
-  defaultProps: {
-    image: true,
-    arrow: true,
-    target: "_self",
-  },
-});
+export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
+  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
+};
 
 <style global jsx>{`
   img.fullsize {

--- a/pages/beta-preview/active-features/computer-use.mdx
+++ b/pages/beta-preview/active-features/computer-use.mdx
@@ -5,9 +5,7 @@ description: "Enable an AI to autonomously use your computer to complete tasks"
 
 import { Callout, Cards } from "nextra/components";
 import Image from "next/image";
-export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
-  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
-};
+import { Card } from "../../../components/card";
 
 <style global jsx>{`
   img.fullsize {

--- a/pages/beta-preview/active-features/live-document-sync.mdx
+++ b/pages/beta-preview/active-features/live-document-sync.mdx
@@ -5,9 +5,7 @@ description: "Access the automatic remote and local document sync beta preview"
 
 import { Callout, Cards } from "nextra/components";
 import Image from "next/image";
-export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
-  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
-};
+import { Card } from "../../../components/card";
 
 <style global jsx>{`
   img {

--- a/pages/beta-preview/active-features/live-document-sync.mdx
+++ b/pages/beta-preview/active-features/live-document-sync.mdx
@@ -5,14 +5,9 @@ description: "Access the automatic remote and local document sync beta preview"
 
 import { Callout, Cards } from "nextra/components";
 import Image from "next/image";
-export const Card = Object.assign(Cards.Card.bind(), {
-  displayName: "Card",
-  defaultProps: {
-    image: true,
-    arrow: true,
-    target: "_self",
-  },
-});
+export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
+  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
+};
 
 <style global jsx>{`
   img {

--- a/pages/beta-preview/overview.mdx
+++ b/pages/beta-preview/overview.mdx
@@ -5,18 +5,9 @@ description: "Access cutting-edge beta previews and features of AnythingLLM"
 
 import { Callout, Cards } from "nextra/components";
 import Image from "next/image";
-export const Card = Object.assign(
-  // Copy card component and add default props
-  Cards.Card.bind(),
-  {
-    displayName: "Card",
-    defaultProps: {
-      image: true,
-      arrow: true,
-      target: "_self",
-    },
-  }
-);
+export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
+  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
+};
 
 <style global jsx>{`
   img {

--- a/pages/beta-preview/overview.mdx
+++ b/pages/beta-preview/overview.mdx
@@ -5,9 +5,7 @@ description: "Access cutting-edge beta previews and features of AnythingLLM"
 
 import { Callout, Cards } from "nextra/components";
 import Image from "next/image";
-export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
-  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
-};
+import { Card } from "../../components/card";
 
 <style global jsx>{`
   img {

--- a/pages/changelog/overview.mdx
+++ b/pages/changelog/overview.mdx
@@ -7,6 +7,7 @@ import { Cards } from "nextra/components";
 import Image from "next/image";
 import Link from "next/link";
 import META from "./_meta.json";
+import { Card } from "../../components/card";
 
 <Image
   src="/images/product/changelog/header-image.png"
@@ -42,9 +43,6 @@ You can read the recent changelogs by clicking the cards below:
     })}
 </Cards>
 
-export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
-  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
-};
 
 <style global jsx>{`
   img {

--- a/pages/changelog/overview.mdx
+++ b/pages/changelog/overview.mdx
@@ -42,18 +42,9 @@ You can read the recent changelogs by clicking the cards below:
     })}
 </Cards>
 
-export const Card = Object.assign(
-  // Copy card component and add default props
-  Cards.Card.bind(),
-  {
-    displayName: "Card",
-    defaultProps: {
-      image: true,
-      arrow: true,
-      target: "_self",
-    },
-  }
-);
+export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
+  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
+};
 
 <style global jsx>{`
   img {

--- a/pages/changelog/v1.7.2.mdx
+++ b/pages/changelog/v1.7.2.mdx
@@ -39,10 +39,10 @@ Additionally, the default embedder model is able to run on the NPU as well with 
   height="450"
   src="https://www.youtube.com/embed/iQvHtubnfcI?si=McTUvuPNCc_AtGIM"
   title="YouTube video player"
-  frameborder="0"
+  frameBorder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-  referrerpolicy="strict-origin-when-cross-origin"
-  allowfullscreen
+  referrerPolicy="strict-origin-when-cross-origin"
+  allowFullScreen
 ></iframe>
 
 ## Improvements:

--- a/pages/contribute.mdx
+++ b/pages/contribute.mdx
@@ -5,6 +5,7 @@ description: "Contribute to AnythingLLM"
 
 import { Cards } from "nextra/components";
 import Image from "next/image";
+import { Card } from "../components/card";
 
 <Image
   src="/images/home/contribute.png"
@@ -105,9 +106,6 @@ Thank you for considering contributing to AnythingLLM. Your support helps make t
   </Card>
 </Cards>
 
-export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
-  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
-};
 
 <style global jsx>{`
   img {

--- a/pages/contribute.mdx
+++ b/pages/contribute.mdx
@@ -105,18 +105,9 @@ Thank you for considering contributing to AnythingLLM. Your support helps make t
   </Card>
 </Cards>
 
-export const Card = Object.assign(
-  // Copy card component and add default props
-  Cards.Card.bind(),
-  {
-    displayName: "Card",
-    defaultProps: {
-      image: true,
-      arrow: true,
-      target: "_self",
-    },
-  }
-);
+export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
+  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
+};
 
 <style global jsx>{`
   img {

--- a/pages/features/all-features.mdx
+++ b/pages/features/all-features.mdx
@@ -156,18 +156,9 @@ Click the below cards to know more about the features
   </Card>
 </Cards>
 
-export const Card = Object.assign(
-  // Copy card component and add default props
-  Cards.Card.bind(),
-  {
-    displayName: "Card",
-    defaultProps: {
-      image: true,
-      arrow: true,
-      target: "_self",
-    },
-  }
-);
+export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
+  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
+};
 
 <style global jsx>{`
   img {

--- a/pages/features/all-features.mdx
+++ b/pages/features/all-features.mdx
@@ -5,6 +5,7 @@ description: "All the features of AnythingLLM"
 
 import { Cards } from "nextra/components";
 import Image from "next/image";
+import { Card } from "../../components/card";
 
 <Image
   src="/images/features/header-image.png"
@@ -156,9 +157,6 @@ Click the below cards to know more about the features
   </Card>
 </Cards>
 
-export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
-  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
-};
 
 <style global jsx>{`
   img {

--- a/pages/features/embedding-models.mdx
+++ b/pages/features/embedding-models.mdx
@@ -103,18 +103,9 @@ Embedding models are specific types of models that turn text into vectors, which
   </Card> 
 </Cards>
 
-export const Card = Object.assign(
-  // Copy card component and add default props
-  Cards.Card.bind(),
-  {
-    displayName: "Card",
-    defaultProps: {
-      image: true,
-      arrow: true,
-      target: "_self",
-    },
-  }
-);
+export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
+  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
+};
 
 <style global jsx>{`
   img {

--- a/pages/features/embedding-models.mdx
+++ b/pages/features/embedding-models.mdx
@@ -5,6 +5,7 @@ description: "AnythingLLM supports many embedding model providers out of the box
 
 import { Cards } from "nextra/components";
 import Image from "next/image";
+import { Card } from "../../components/card";
 
 <Image
   src="/images/features/embedding-models/header-image.png"
@@ -103,9 +104,6 @@ Embedding models are specific types of models that turn text into vectors, which
   </Card> 
 </Cards>
 
-export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
-  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
-};
 
 <style global jsx>{`
   img {

--- a/pages/features/language-models.mdx
+++ b/pages/features/language-models.mdx
@@ -5,6 +5,7 @@ description: "AnythingLLM allows you to use a host of LLM providers for chatting
 
 import { Cards, Callout } from "nextra/components";
 import Image from "next/image";
+import { Card } from "../../components/card";
 
 <Image
   src="/images/features/language-models/header-image.png"
@@ -220,9 +221,6 @@ Depending on your selection additional configuration might be required.
   
 </Cards>
 
-export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
-  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
-};
 
 <style global jsx>{`
   img {

--- a/pages/features/language-models.mdx
+++ b/pages/features/language-models.mdx
@@ -220,18 +220,9 @@ Depending on your selection additional configuration might be required.
   
 </Cards>
 
-export const Card = Object.assign(
-  // Copy card component and add default props
-  Cards.Card.bind(),
-  {
-    displayName: "Card",
-    defaultProps: {
-      image: true,
-      arrow: true,
-      target: "_self",
-    },
-  }
-);
+export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
+  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
+};
 
 <style global jsx>{`
   img {

--- a/pages/features/transcription-models.mdx
+++ b/pages/features/transcription-models.mdx
@@ -5,6 +5,7 @@ description: "AnythingLLM supports custom audio transcription providers."
 
 import { Cards } from "nextra/components";
 import Image from "next/image";
+import { Card } from "../../components/card";
 
 <Image
   src="/images/features/transcription-models/header-image.png"
@@ -51,9 +52,6 @@ AnythingLLM supports custom audio transcription providers.
   </Card>
 </Cards>
 
-export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
-  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
-};
 
 <style global jsx>{`
   img {

--- a/pages/features/transcription-models.mdx
+++ b/pages/features/transcription-models.mdx
@@ -51,18 +51,9 @@ AnythingLLM supports custom audio transcription providers.
   </Card>
 </Cards>
 
-export const Card = Object.assign(
-  // Copy card component and add default props
-  Cards.Card.bind(),
-  {
-    displayName: "Card",
-    defaultProps: {
-      image: true,
-      arrow: true,
-      target: "_self",
-    },
-  }
-);
+export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
+  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
+};
 
 <style global jsx>{`
   img {

--- a/pages/features/vector-databases.mdx
+++ b/pages/features/vector-databases.mdx
@@ -120,18 +120,9 @@ AnythingLLM supports many vector databases providers out of the box.
 </Card>
 </Cards>
 
-export const Card = Object.assign(
-  // Copy card component and add default props
-  Cards.Card.bind(),
-  {
-    displayName: "Card",
-    defaultProps: {
-      image: true,
-      arrow: true,
-      target: "_self",
-    },
-  }
-);
+export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
+  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
+};
 
 <style global jsx>{`
   img {

--- a/pages/features/vector-databases.mdx
+++ b/pages/features/vector-databases.mdx
@@ -5,6 +5,7 @@ description: "AnythingLLM allows you to use a host of LLM providers for chatting
 
 import { Cards } from "nextra/components";
 import Image from "next/image";
+import { Card } from "../../components/card";
 
 <Image
   src="/images/features/vector-databases/header-image.png"
@@ -120,9 +121,6 @@ AnythingLLM supports many vector databases providers out of the box.
 </Card>
 </Cards>
 
-export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
-  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
-};
 
 <style global jsx>{`
   img {

--- a/pages/import-custom-models.mdx
+++ b/pages/import-custom-models.mdx
@@ -56,10 +56,10 @@ video segment.
   height="500"
   src="https://www.youtube.com/embed/1B50IDUl5D4?si=2SdTcSFxMzbQiD8e&amp;start=710"
   title="YouTube video player"
-  frameborder="0"
+  frameBorder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-  referrerpolicy="strict-origin-when-cross-origin"
-  allowfullscreen
+  referrerPolicy="strict-origin-when-cross-origin"
+  allowFullScreen
 ></iframe>
 
 ## How to import into LMStudio
@@ -72,8 +72,8 @@ video segment.
   height="500"
   src="https://www.youtube.com/embed/1B50IDUl5D4?si=lVYaAlLHxFuonepb&amp;start=1050"
   title="YouTube video player"
-  frameborder="0"
+  frameBorder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-  referrerpolicy="strict-origin-when-cross-origin"
-  allowfullscreen
+  referrerPolicy="strict-origin-when-cross-origin"
+  allowFullScreen
 ></iframe>

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -74,18 +74,9 @@ Learn about AnythingLLM's features and how to use them
   </Card>  
 </Cards>
 
-export const Card = Object.assign(
-  // Copy card component and add default props
-  Cards.Card.bind(),
-  {
-    displayName: "Card",
-    defaultProps: {
-      image: true,
-      arrow: true,
-      target: "_self",
-    },
-  }
-);
+export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
+  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
+};
 
 <style global jsx>{`
   img {

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -5,6 +5,7 @@ description: "Learn about AnythingLLM's features and how to use them"
 
 import { Cards } from "nextra/components";
 import Image from "next/image";
+import { Card } from "../components/card";
 
 # AnythingLLM Documentation
 
@@ -74,9 +75,6 @@ Learn about AnythingLLM's features and how to use them
   </Card>  
 </Cards>
 
-export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
-  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
-};
 
 <style global jsx>{`
   img {

--- a/pages/installation-desktop/macos.mdx
+++ b/pages/installation-desktop/macos.mdx
@@ -5,6 +5,7 @@ description: "MacOS Installation guide for AnythingLLM"
 
 import { Callout, Cards } from "nextra/components";
 import Image from "next/image";
+import { Card } from "../../components/card";
 
 <Image
   src="/images/getting-started/installation/macos/header-image.png"
@@ -56,9 +57,6 @@ Here is the download links for the latest version of Anything LLM MacOS.
   </Card>
 </Cards>
 
-export const Card = ({ image = false, arrow = true, target = "_blank", ...props }) => {
-  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
-};
 
 Your internet browser may need you to verify you want to download and run the AnythingLLM Desktop app since it may be marked as "untrusted" depending on your browser security settings.
 

--- a/pages/installation-desktop/macos.mdx
+++ b/pages/installation-desktop/macos.mdx
@@ -56,18 +56,9 @@ Here is the download links for the latest version of Anything LLM MacOS.
   </Card>
 </Cards>
 
-export const Card = Object.assign(
-  // Copy card component and add default props
-  Cards.Card.bind(),
-  {
-    displayName: "Card",
-    defaultProps: {
-      image: false,
-      arrow: true,
-      target: "_blank",
-    },
-  }
-);
+export const Card = ({ image = false, arrow = true, target = "_blank", ...props }) => {
+  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
+};
 
 Your internet browser may need you to verify you want to download and run the AnythingLLM Desktop app since it may be marked as "untrusted" depending on your browser security settings.
 

--- a/pages/installation-desktop/overview.mdx
+++ b/pages/installation-desktop/overview.mdx
@@ -5,6 +5,7 @@ description: "AnythingLLM desktop is the easiest way to use AnythingLLM for most
 
 import { Callout, Cards } from "nextra/components";
 import Image from "next/image";
+import { Card } from "../../components/card";
 
 <Image
   src="/images/getting-started/installation/header-image.png"
@@ -147,9 +148,6 @@ The below table is a non-exhaustive list of features supported between platforms
   </Card>  
 </Cards>
 
-export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
-  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
-};
 
 <style global jsx>{`
   img {

--- a/pages/installation-desktop/overview.mdx
+++ b/pages/installation-desktop/overview.mdx
@@ -147,18 +147,9 @@ The below table is a non-exhaustive list of features supported between platforms
   </Card>  
 </Cards>
 
-export const Card = Object.assign(
-  // Copy card component and add default props
-  Cards.Card.bind(),
-  {
-    displayName: "Card",
-    defaultProps: {
-      image: true,
-      arrow: true,
-      target: "_self",
-    },
-  }
-);
+export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
+  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
+};
 
 <style global jsx>{`
   img {

--- a/pages/installation-desktop/windows.mdx
+++ b/pages/installation-desktop/windows.mdx
@@ -50,18 +50,9 @@ Here is the download link for the latest version of Anything LLM Windows.
   href="https://cdn.anythingllm.com/latest/AnythingLLMDesktop-Arm64.exe"
 ></Card>
 
-export const Card = Object.assign(
-  // Copy card component and add default props
-  Cards.Card.bind(),
-  {
-    displayName: "Card",
-    defaultProps: {
-      image: false,
-      arrow: true,
-      target: "_blank",
-    },
-  }
-);
+export const Card = ({ image = false, arrow = true, target = "_blank", ...props }) => {
+  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
+};
 
 Your internet browser may need you to verify you want to download and run the AnythingLLM Desktop app since it may be marked as "untrusted" depending on your browser security settings.
 

--- a/pages/installation-desktop/windows.mdx
+++ b/pages/installation-desktop/windows.mdx
@@ -5,6 +5,7 @@ description: "Windows Installation guide for AnythingLLM"
 
 import { Callout, Cards } from "nextra/components";
 import Image from "next/image";
+import { Card } from "../../components/card";
 
 <Image
   src="/images/getting-started/installation/windows/header-image.png"
@@ -50,9 +51,6 @@ Here is the download link for the latest version of Anything LLM Windows.
   href="https://cdn.anythingllm.com/latest/AnythingLLMDesktop-Arm64.exe"
 ></Card>
 
-export const Card = ({ image = false, arrow = true, target = "_blank", ...props }) => {
-  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
-};
 
 Your internet browser may need you to verify you want to download and run the AnythingLLM Desktop app since it may be marked as "untrusted" depending on your browser security settings.
 

--- a/pages/introduction.mdx
+++ b/pages/introduction.mdx
@@ -50,8 +50,8 @@ If either of these things excite you - you will love watching the video below.
   height="450"
   src="https://www.youtube.com/embed/-Rs8-M-xBFI?si=IdsgmFwdJuouqeMd"
   title="YouTube video player"
-  frameborder="0"
+  frameBorder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-  referrerpolicy="strict-origin-when-cross-origin"
-  allowfullscreen
+  referrerPolicy="strict-origin-when-cross-origin"
+  allowFullScreen
 ></iframe>

--- a/pages/mcp-compatibility/overview.mdx
+++ b/pages/mcp-compatibility/overview.mdx
@@ -5,18 +5,9 @@ description: "Use existing MCP Servers with AnythingLLM Agents"
 
 import { Cards, Callout } from "nextra/components";
 import Image from "next/image";
-export const Card = Object.assign(
-  // Copy card component and add default props
-  Cards.Card.bind(),
-  {
-    displayName: "Card",
-    defaultProps: {
-      image: true,
-      arrow: true,
-      target: "_self",
-    },
-  }
-);
+export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
+  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
+};
 
 <Image
   src="/images/mcp-compatibility/mcp.png"

--- a/pages/mcp-compatibility/overview.mdx
+++ b/pages/mcp-compatibility/overview.mdx
@@ -5,9 +5,7 @@ description: "Use existing MCP Servers with AnythingLLM Agents"
 
 import { Cards, Callout } from "nextra/components";
 import Image from "next/image";
-export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
-  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
-};
+import { Card } from "../../components/card";
 
 <Image
   src="/images/mcp-compatibility/mcp.png"

--- a/pages/nvidia-nims/introduction.mdx
+++ b/pages/nvidia-nims/introduction.mdx
@@ -8,7 +8,8 @@ import { Callout } from "nextra/components";
 <Callout type="warning">
   NVIDIA NIM is currently in **beta** and is only available on Windows 11 on **AnythingLLM Desktop v.1.7.8** and above.
 
-  You can download the latest version of AnythingLLM Desktop (v.1.7.8+) [here](https://anythingllm.com/download).
+You can download the latest version of AnythingLLM Desktop (v.1.7.8+) [here](https://anythingllm.com/download).
+
 </Callout>
 
 # What is NVIDIA NIM?
@@ -22,10 +23,10 @@ NVIDIA NIM is currently in **beta** and is only available on Windows 11 on **Any
 
 ## Privacy
 
-NVIDIA NIM models run __fully__ locally on your machine using your own GPU. AnythingLLM does not send any data to NVIDIA or any other third party in order to run NIM models.
+NVIDIA NIM models run **fully** locally on your machine using your own GPU. AnythingLLM does not send any data to NVIDIA or any other third party in order to run NIM models.
 After a model is installed, it is present on your local machine and AnythingLLM will use this local engine for inference.
 
-NVIDIA NIM on RTX is __not to be confused__ with NVIDIA's cloud-based NIM offering. This is a __completely__ separate product and service designed to run NIM on your local RTX GPU.
+NVIDIA NIM on RTX is **not to be confused** with NVIDIA's cloud-based NIM offering. This is a **completely** separate product and service designed to run NIM on your local RTX GPU.
 
 ## How does it work?
 
@@ -55,13 +56,12 @@ See the [NVIDIA NIM x AnythingLLM Walkthrough](/nvidia-nims/walkthrough) for the
 
 ## Video Walkthrough & Overview
 
-<iframe  
+<iframe
   width="100%"
-  height="450" 
-  src="https://www.youtube.com/embed/Q7eZJupnba4" 
-  title="YouTube video player" 
+  height="450"
+  src="https://www.youtube.com/embed/Q7eZJupnba4"
+  title="YouTube video player"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-  referrerpolicy="strict-origin-when-cross-origin"
-  allowfullscreen
+  referrerPolicy="strict-origin-when-cross-origin"
+  allowFullScreen
 ></iframe>
-

--- a/pages/setup/embedder-configuration/overview.mdx
+++ b/pages/setup/embedder-configuration/overview.mdx
@@ -118,18 +118,9 @@ You can modify your embedding provider and model at any time in AnythingLLM. How
   </Card>  
 </Cards>
 
-export const Card = Object.assign(
-  // Copy card component and add default props
-  Cards.Card.bind(),
-  {
-    displayName: "Card",
-    defaultProps: {
-      image: true,
-      arrow: true,
-      target: "_self",
-    },
-  }
-);
+export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
+  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
+};
 
 <style global jsx>{`
   img {

--- a/pages/setup/embedder-configuration/overview.mdx
+++ b/pages/setup/embedder-configuration/overview.mdx
@@ -5,6 +5,7 @@ description: "Embedding models are specific types of models that turn text into 
 
 import { Cards, Callout } from "nextra/components";
 import Image from "next/image";
+import { Card } from "../../../components/card";
 
 <Image
   src="/images/anythingllm-setup/embedder-configuration/header-image.png"
@@ -118,9 +119,6 @@ You can modify your embedding provider and model at any time in AnythingLLM. How
   </Card>  
 </Cards>
 
-export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
-  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
-};
 
 <style global jsx>{`
   img {

--- a/pages/setup/llm-configuration/overview.mdx
+++ b/pages/setup/llm-configuration/overview.mdx
@@ -5,6 +5,7 @@ description: "Large language models are AI systems capable of understanding and 
 
 import { Cards, Callout } from "nextra/components";
 import Image from "next/image";
+import { Card } from "../../../components/card";
 
 <Image
   src="/images/anythingllm-setup/llm-configuration/header-image.png"
@@ -227,9 +228,6 @@ We allow you to connect to both local and cloud-based LLMs - even at the same ti
   </Card>
 </Cards>
 
-export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
-  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
-};
 
 <style global jsx>{`
   img {

--- a/pages/setup/llm-configuration/overview.mdx
+++ b/pages/setup/llm-configuration/overview.mdx
@@ -227,18 +227,9 @@ We allow you to connect to both local and cloud-based LLMs - even at the same ti
   </Card>
 </Cards>
 
-export const Card = Object.assign(
-  // Copy card component and add default props
-  Cards.Card.bind(),
-  {
-    displayName: "Card",
-    defaultProps: {
-      image: true,
-      arrow: true,
-      target: "_self",
-    },
-  }
-);
+export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
+  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
+};
 
 <style global jsx>{`
   img {

--- a/pages/setup/transcription-model-configuration/overview.mdx
+++ b/pages/setup/transcription-model-configuration/overview.mdx
@@ -5,6 +5,7 @@ description: "AnythingLLM supports custom audio transcription providers."
 
 import { Cards } from "nextra/components";
 import Image from "next/image";
+import { Card } from "../../../components/card";
 
 <Image
   src="/images/anythingllm-setup/transcription-model-configuration/header-image.png"
@@ -48,9 +49,6 @@ AnythingLLM supports custom audio transcription providers.
   </Card>
 </Cards>
 
-export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
-  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
-};
 
 <style global jsx>{`
   img {

--- a/pages/setup/transcription-model-configuration/overview.mdx
+++ b/pages/setup/transcription-model-configuration/overview.mdx
@@ -48,18 +48,9 @@ AnythingLLM supports custom audio transcription providers.
   </Card>
 </Cards>
 
-export const Card = Object.assign(
-  // Copy card component and add default props
-  Cards.Card.bind(),
-  {
-    displayName: "Card",
-    defaultProps: {
-      image: true,
-      arrow: true,
-      target: "_self",
-    },
-  }
-);
+export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
+  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
+};
 
 <style global jsx>{`
   img {

--- a/pages/setup/vector-database-configuration/local/chroma.mdx
+++ b/pages/setup/vector-database-configuration/local/chroma.mdx
@@ -50,8 +50,8 @@ You can configure Chroma at any time in the **Settings**.
   height="450"
   src="https://www.youtube.com/embed/61kaK-e3Owc?si=5mdkTqKCZG4Nvn0-"
   title="YouTube video player"
-  frameborder="0"
+  frameBorder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-  referrerpolicy="strict-origin-when-cross-origin"
-  allowfullscreen
+  referrerPolicy="strict-origin-when-cross-origin"
+  allowFullScreen
 ></iframe>

--- a/pages/setup/vector-database-configuration/overview.mdx
+++ b/pages/setup/vector-database-configuration/overview.mdx
@@ -119,18 +119,9 @@ AnythingLLM supports many vector databases providers out of the box.
   </Card>
 </Cards>
 
-export const Card = Object.assign(
-  // Copy card component and add default props
-  Cards.Card.bind(),
-  {
-    displayName: "Card",
-    defaultProps: {
-      image: true,
-      arrow: true,
-      target: "_self",
-    },
-  }
-);
+export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
+  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
+};
 
 <style global jsx>{`
   img {

--- a/pages/setup/vector-database-configuration/overview.mdx
+++ b/pages/setup/vector-database-configuration/overview.mdx
@@ -5,6 +5,7 @@ description: "Your vector database is set system-wide and cannot be configured a
 
 import { Cards, Callout } from "nextra/components";
 import Image from "next/image";
+import { Card } from "../../../components/card";
 
 <Image
   src="/images/anythingllm-setup/vector-database-configuration/header-image.png"
@@ -119,9 +120,6 @@ AnythingLLM supports many vector databases providers out of the box.
   </Card>
 </Cards>
 
-export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
-  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
-};
 
 <style global jsx>{`
   img {

--- a/pages/support.mdx
+++ b/pages/support.mdx
@@ -5,6 +5,7 @@ description: "Support for AnythingLLM"
 
 import { Callout, Cards } from "nextra/components";
 import Image from "next/image";
+import { Card } from "../components/card";
 
 <Image
   src="/images/getting-started/support/header-image.png"
@@ -71,9 +72,6 @@ Join Mintplex Labs Discord [Community Server](https://discord.gg/Dh4zSZCdsC) and
   </Card>
 </Cards>
 
-export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
-  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
-};
 
 <style global jsx>{`
   img {

--- a/pages/support.mdx
+++ b/pages/support.mdx
@@ -71,18 +71,9 @@ Join Mintplex Labs Discord [Community Server](https://discord.gg/Dh4zSZCdsC) and
   </Card>
 </Cards>
 
-export const Card = Object.assign(
-  // Copy card component and add default props
-  Cards.Card.bind(),
-  {
-    displayName: "Card",
-    defaultProps: {
-      image: true,
-      arrow: true,
-      target: "_self",
-    },
-  }
-);
+export const Card = ({ image = true, arrow = true, target = "_self", ...props }) => {
+  return <Cards.Card image={image} arrow={arrow} target={target} {...props} />;
+};
 
 <style global jsx>{`
   img {


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #191 


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the documentation site. -->

This PR includes some changes to code that were causing console errors and warning on dev startup with `yarn dev`

1. Fixes the incorrect property usage in `_meta.json` to hide the page from navigation for `intro`, `default-blocks` and `community-hub`

2. Fixes deprecated usage of `defaultProps` for the Nextra `Card` component across all page files.


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

These changes should suppress warnings that appear similar to the following:

```
[nextra-theme-docs] Error validating _meta.json file for "community-hub" property.

Invalid input
Invalid input
Invalid input
Expected string, received object
Required. Path: "items"
Invalid literal value, expected "menu". Path: "type"
Invalid literal value, expected "separator". Path: "type"
Invalid enum value. Expected 'page' | 'doc', received 'hidden'. Path: "type"
[nextra-theme-docs] Error validating _meta.json file for "intro" property.

Unrecognized key(s) in object: 'hidden'. Path: "theme"
[nextra-theme-docs] Error validating _meta.json file for "default-blocks" property.

Unrecognized key(s) in object: 'hidden'. Path: "theme"
Warning: Card: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
    at Card (webpack-internal:///./node_modules/nextra/dist/components/cards.js:37:3)
    at div
    at _Cards (webpack-internal:///./node_modules/nextra/dist/components/cards.js:105:3)
    at MDXContent (webpack-internal:///./pages/index.mdx:206:114)
    at MDXProvider (file:///Users/macfitton/coding/mintplex-labs/anythingllm-docs/node_modules/@mdx-js/react/lib/index.js:90:30)
    at main
    at article
    at Body (webpack-internal:///./node_modules/nextra-theme-docs/dist/index.js:2918:3)
    at ActiveAnchorProvider (webpack-internal:///./node_modules/nextra-theme-docs/dist/index.js:156:3)
    at div
    at div
    at InnerLayout (webpack-internal:///./node_modules/nextra-theme-docs/dist/index.js:2969:3)
    at m (/Users/macfitton/coding/mintplex-labs/anythingllm-docs/node_modules/next-themes/dist/index.js:1:310)
    at exports.ThemeProvider (/Users/macfitton/coding/mintplex-labs/anythingllm-docs/node_modules/next-themes/dist/index.js:1:3611)
    at ConfigProvider (webpack-internal:///./node_modules/nextra-theme-docs/dist/index.js:262:3)
    at Layout (webpack-internal:///./node_modules/nextra-theme-docs/dist/index.js:3088:5)
    at Nextra (webpack-internal:///./node_modules/nextra/dist/layout.js:17:3)
    at MyApp (webpack-internal:///./pages/_app.tsx:11:18)
    at StyleRegistry (/Users/macfitton/coding/mintplex-labs/anythingllm-docs/node_modules/styled-jsx/dist/index/index.js:449:36)
    at eU (/Users/macfitton/coding/mintplex-labs/anythingllm-docs/node_modules/next/dist/compiled/next-server/pages.runtime.dev.js:8:20489)
    at eH (/Users/macfitton/coding/mintplex-labs/anythingllm-docs/node_modules/next/dist/compiled/next-server/pages.runtime.dev.js:17:1788)
    at eJ (/Users/macfitton/coding/mintplex-labs/anythingllm-docs/node_modules/next/dist/compiled/next-server/pages.runtime.dev.js:17:3091)
    at div
    at e9 (/Users/macfitton/coding/mintplex-labs/anythingllm-docs/node_modules/next/dist/compiled/next-server/pages.runtime.dev.js:26:761)



```

### Validations

<!-- All of the applicable items should be checked. -->

- [x] Ensured updated documentation pass spell check
- [x] Updated or added relevant links as needed
- [x] Reviewed the changes for clarity and accuracy
- [x] Successfully ran the code locally without encountering errors
