### PR TITLE
docs: Linux limitation callouts for Desktop & Meeting Assistant

### DIFF
--- a/pages/desktop-assistant/features.mdx
+++ b/pages/desktop-assistant/features.mdx
@@ -14,6 +14,10 @@ In general, anything you can do in the main AnythingLLM UI you can do in the Des
 
 ## Chat with any open application
 
+<Callout type="warning" emoji="🐧">
+  **Not supported on Linux:** Application capture is unavailable on Linux. The Desktop Assistant on Linux cannot capture individual applications for screenshots.
+</Callout>
+
 By default, the Desktop Assistant is able to chat with any open application using the full context of any application (Chrome, Slack, VS Code, etc.).
 
 You can select the current active application suggestion in the chat window or click the "+" icon show all available applications.
@@ -29,6 +33,10 @@ You can select the current active application suggestion in the chat window or c
 />
 
 ## Full screen & area capture
+
+<Callout type="warning" emoji="🐧">
+  **Not supported on Linux:** Full display and area capture are unavailable on Linux. The Desktop Assistant on Linux cannot capture displays or screen regions for screenshots.
+</Callout>
 
 In the "+" menu, you can select "Area Capture" to capture a specific area of the screen or select a display to capture the full screen of that display.
 

--- a/pages/desktop-assistant/introduction.mdx
+++ b/pages/desktop-assistant/introduction.mdx
@@ -43,8 +43,12 @@ Any chats, agentic tasks, or MCPs are processed using your LLM provider and mode
 - [x] MacOS Intel
 - [x] Windows x64
 - [x] Windows ARM64
-- [x] Linux x64
-- [x] Linux ARM64
+- [x] Linux x64 (limited)
+- [x] Linux ARM64 (limited)
+
+<Callout type="warning" emoji="🐧">
+  **Linux limitations:** The Desktop Assistant on Linux cannot capture individual applications, displays, or screen regions. Features that depend on screen capture - including [chat with any open application](/desktop-assistant/features#chat-with-any-open-application) and [full screen & area capture](/desktop-assistant/features#full-screen--area-capture) - are unavailable on Linux.
+</Callout>
 
 ## Frequently Asked Questions
 

--- a/pages/meeting-assistant/features.mdx
+++ b/pages/meeting-assistant/features.mdx
@@ -10,6 +10,9 @@ import Image from "next/image";
   The Meeting Assistant is only available in AnythingLLM Desktop v1.10.0 and later for [supported platforms](/meeting-assistant/introduction#supported-platforms).
 </Callout>
 
+<Callout type="warning" emoji="🐧">
+  **Coming soon to Linux:** The Meeting Assistant is not yet available on Linux (both x64 and ARM64). None of the features described on this page are available on Linux today.
+</Callout>
 
 ## Record and transcribe meetings
 

--- a/pages/meeting-assistant/introduction.mdx
+++ b/pages/meeting-assistant/introduction.mdx
@@ -12,6 +12,10 @@ import Image from "next/image";
   The Meeting Assistant is a tool that helps you record, transcribe, and summarize meetings complete with agentic follow-up actions.
 </Callout>
 
+<Callout type="warning" emoji="🐧">
+  **Coming soon to Linux:** The Meeting Assistant is not yet available on Linux (both x64 and ARM64). This feature is currently only available on MacOS and Windows.
+</Callout>
+
 # Meeting Assistant
 
 The AnythingLLM Meeting Assistant is a tool that brings all the power of paid SaaS meeting assistants to your local device, all using local models with absolutely no data leaving your device.
@@ -80,8 +84,8 @@ All other hardware is supported, but may not be as performant, but will still wo
 - [x] MacOS Intel
 - [x] Windows x64
 - [x] Windows ARM64
-- [-] Linux x64 (Coming Soon)
-- [-] Linux ARM64 (Coming Soon)
+- [ ] Linux x64 (Coming Soon)
+- [ ] Linux ARM64 (Coming Soon)
 
 ### Minimum System Requirements
 


### PR DESCRIPTION
### Pull Request Type

- [x] ✨ feat

### Relevant Issues

resolves #240

### What is in this change?

Adds Linux limitation callouts to the Desktop Assistant and Meeting Assistant docs:

- **Desktop Assistant** (`pages/desktop-assistant/features.mdx`, `introduction.mdx`): Per-section warning callouts on "Chat with any open application" and "Full screen & area capture" noting these features are unavailable on Linux because the Linux Desktop Assistant cannot capture individual applications, displays, or screen regions for screenshots. Supported Platforms list now marks Linux x64/ARM64 as `(limited)` with a summary callout linking to the affected features.
- **Meeting Assistant** (`pages/meeting-assistant/features.mdx`, `introduction.mdx`): Top-of-page "Coming soon to Linux" callouts on both pages. Supported Platforms list fixed to use `[ ]` instead of `[-]` so Linux entries render as empty checkboxes.

### Additional Information

The Meeting Assistant is not yet available on Linux (framed as "coming soon"), while the Desktop Assistant runs on Linux but without screen-capture-based features.


### Validations

- [x] Ensured updated documentation pass spell check
- [x] Updated or added relevant links as needed
- [x] Reviewed the changes for clarity and accuracy
- [x] Successfully ran the code locally without encountering errors