### PR TITLE
docs(privacy): clarify document deletion vs workspace removal for full erasure

### DIFF
--- a/pages/features/privacy-and-data-handling.mdx
+++ b/pages/features/privacy-and-data-handling.mdx
@@ -38,3 +38,20 @@ AnythingLLM collects anonymous telemetry and never collects any of your personal
 We collect telemetry to help improve our product.
 
 If for any reason you would not like to participate in sharing telemetry with us, you can disable it in this menu.
+
+## Deleting documents and full erasure
+
+Removing a document can mean two different things in AnythingLLM, and they behave differently:
+
+- **Removing a document from a workspace** stops that workspace from using it and deletes its vectors from that workspace — but the document stays in **My Documents** (your document library) so it can be re-used in other workspaces without re-parsing.
+- **Deleting a document from My Documents** removes it from the system entirely: it deletes the parsed source file and the cached embeddings, and removes the document from **every** workspace.
+
+<Callout type="warning" emoji="⚠️">
+  **Right-to-erasure / data-deletion requests:**
+
+  To completely erase a document — both its parsed text and its cached
+  embeddings — delete it from **My Documents**, not just from a workspace.
+  Removing a document from a single workspace intentionally leaves the parsed
+  file and cache in place so it can be re-used.
+
+</Callout>


### PR DESCRIPTION
### What
Adds a short **"Deleting documents and full erasure"** section to the Privacy & Data page.

### Why
The distinction between *removing a document from a workspace* and *deleting it from My Documents* isn't documented anywhere, and it matters for data-deletion / right-to-erasure requests:

- **Remove from a workspace** (`Document.removeDocuments`) deletes that workspace's vectors but **keeps** the parsed source file and cached embeddings in the document library (intentional, for reuse).
- **Delete from My Documents** (`purgeDocument`) is the full erasure path — it calls `purgeSourceDocument` + `purgeVectorCache` and removes the document from every workspace.

An operator fulfilling a GDPR/DSR erasure request who only removes a document from a workspace would leave the parsed text and vector cache on disk. This documents the correct path. No behavior change — docs only.

### Disclosure
Surfaced while testing a self-hosted instance with an automated multi-tenant-isolation checker ([Sectum AI](https://github.com/sectum-ai/sectum-ai)); drafted with AI assistance.