### PR TITLE
docs(configuration): document EMBED_REQUIRE_ALLOWLIST

### DIFF
--- a/pages/configuration.mdx
+++ b/pages/configuration.mdx
@@ -411,7 +411,7 @@ ANYTHINGLLM_MAX_RETRIES="2" # Retry failed requests up to 2 times.
 
 Fully remove or comment out the `ANYTHINGLLM_MAX_RETRIES` environment variable to return to the default behavior (0 retries).
 
-## Require an allowlist for embed widgets
+## Require Allowlist for Embed Widgets
 
 By default, a public chat embed widget created **without** an allowed-domains allowlist responds to requests from **any** origin. Setting the `EMBED_REQUIRE_ALLOWLIST` environment variable makes embeds that have no allowlist configured reject all requests (deny-by-default). Embeds that already have an allowlist set are unaffected.
 

--- a/pages/configuration.mdx
+++ b/pages/configuration.mdx
@@ -411,3 +411,22 @@ ANYTHINGLLM_MAX_RETRIES="2" # Retry failed requests up to 2 times.
 
 Fully remove or comment out the `ANYTHINGLLM_MAX_RETRIES` environment variable to return to the default behavior (0 retries).
 
+## Require an allowlist for embed widgets
+
+By default, a public chat embed widget created **without** an allowed-domains allowlist responds to requests from **any** origin. Setting the `EMBED_REQUIRE_ALLOWLIST` environment variable makes embeds that have no allowlist configured reject all requests (deny-by-default). Embeds that already have an allowlist set are unaffected.
+
+- Useful for administrators who want to ensure an embed cannot be queried cross-origin until its allowed domains are explicitly set.
+- Added in [Mintplex-Labs/anything-llm#5759](https://github.com/Mintplex-Labs/anything-llm/pull/5759).
+
+### Enable
+
+Set the `EMBED_REQUIRE_ALLOWLIST` environment variable to the string `"true"`.
+
+```bash
+EMBED_REQUIRE_ALLOWLIST="true"
+```
+
+### Disable
+
+Fully remove or comment out the `EMBED_REQUIRE_ALLOWLIST` environment variable to return to the default behavior, where an embed with no allowlist answers requests from any origin.
+

--- a/pages/configuration.mdx
+++ b/pages/configuration.mdx
@@ -420,10 +420,10 @@ By default, a public chat embed widget created **without** an allowed-domains al
 
 ### Enable
 
-Set the `EMBED_REQUIRE_ALLOWLIST` environment variable to the string `"true"`.
+Set the `EMBED_REQUIRE_ALLOWLIST` environment variable to any value to enable.
 
 ```bash
-EMBED_REQUIRE_ALLOWLIST="true"
+EMBED_REQUIRE_ALLOWLIST="enable"
 ```
 
 ### Disable


### PR DESCRIPTION
Documents the new `EMBED_REQUIRE_ALLOWLIST` environment variable.

It's the opt-in, deny-by-default flag for chat embed widgets that have no allowed-domains allowlist configured, added in **Mintplex-Labs/anything-llm#5759**. Added as a new section on the Configuration page following the existing per-flag Enable/Disable pattern.

Companion docs PR for Mintplex-Labs/anything-llm#5759 (requested in review).