### PR TITLE
docs: update native tool calling to opt-out (PROVIDER_DISABLE_NATIVE_TOOL_CALLING)

### DIFF
--- a/pages/configuration.mdx
+++ b/pages/configuration.mdx
@@ -326,14 +326,7 @@ Native tool calling is now **enabled by default** for all providers that support
 
 Previously, native tool calling was opt-in via `PROVIDER_SUPPORTS_NATIVE_TOOL_CALLING`. That variable has been replaced — you no longer need to enable native tool calling, only to disable it for providers where it misbehaves.
 
-Providers affected by this flag:
-- Generic OpenAI (`generic-openai`)
-- AWS Bedrock (`bedrock`)
-- Groq (`groq`)
-- Lemonade (`lemonade`)
-- LiteLLM (`litellm`)
-- Local AI (`localai`)
-- OpenRouter (`openrouter`)
+Only `OpenAI` and `Anthropic` are unaffected by this setting and will always use native tool calling regardless of this ENV config.
 
 <Callout type="info" emoji="️💡">
   Because native tool calling is now on by default, workspaces in automatic chat mode using these providers will run the agent automatically without requiring the `@agent` prefix. Disabling native tool calling for a provider restores the previous behavior, where the agent must be invoked explicitly.

--- a/pages/configuration.mdx
+++ b/pages/configuration.mdx
@@ -322,30 +322,38 @@ Fully remove or comment out the `DISABLE_SWAGGER_DOCS` environment variable to r
   **Note:** This setting only applies to local LLM providers. It has no impact on cloud LLMs like OpenAI, Anthropic, or Azure.
 </Callout>
 
-Modification of the `PROVIDER_SUPPORTS_NATIVE_TOOL_CALLING` environment variable allows you to enable native tool calling for supported LLM providers that cannot automatically detect tool calling support.
+Native tool calling is now **enabled by default** for all providers that support it. The `PROVIDER_DISABLE_NATIVE_TOOL_CALLING` environment variable lets you force specific providers to fall back to prompt-based (UnTooled) tool calling instead.
 
-Some providers like Ollama, LM Studio, and the default built-in LLM provider automatically support native tool calling if your model supports it. However, other providers require this environment variable to be set.
+Previously, native tool calling was opt-in via `PROVIDER_SUPPORTS_NATIVE_TOOL_CALLING`. That variable has been replaced — you no longer need to enable native tool calling, only to disable it for providers where it misbehaves.
 
-Providers that require this flag:
-- Generic OpenAI
-- Groq
-- AWS Bedrock
-- Lemonade
-- LiteLLM
-- Local AI
-- OpenRouter
+Providers affected by this flag:
+- Generic OpenAI (`generic-openai`)
+- AWS Bedrock (`bedrock`)
+- Groq (`groq`)
+- Lemonade (`lemonade`)
+- LiteLLM (`litellm`)
+- Local AI (`localai`)
+- OpenRouter (`openrouter`)
 
-### Enable
-
-Set the `PROVIDER_SUPPORTS_NATIVE_TOOL_CALLING` environment variable to a comma-separated list of provider identifiers you want to enable.
-
-```bash
-PROVIDER_SUPPORTS_NATIVE_TOOL_CALLING="bedrock,generic-openai,groq,lemonade,litellm,local-ai,openrouter"
-```
+<Callout type="info" emoji="️💡">
+  Because native tool calling is now on by default, workspaces in automatic chat mode using these providers will run the agent automatically without requiring the `@agent` prefix. Disabling native tool calling for a provider restores the previous behavior, where the agent must be invoked explicitly.
+</Callout>
 
 ### Disable
 
-Fully remove or comment out the `PROVIDER_SUPPORTS_NATIVE_TOOL_CALLING` environment variable to return to the default behavior.
+Set the `PROVIDER_DISABLE_NATIVE_TOOL_CALLING` environment variable to a comma-separated list of provider identifiers you want to revert to prompt-based tool calling. Add a provider here only if its native tool calling misbehaves and you want to fall back.
+
+```bash
+# Disable native tool calling for specific providers.
+PROVIDER_DISABLE_NATIVE_TOOL_CALLING="groq,openrouter"
+
+# Disable for all affected providers.
+PROVIDER_DISABLE_NATIVE_TOOL_CALLING="generic-openai,bedrock,localai,groq,litellm,openrouter,lemonade"
+```
+
+### Enable
+
+Native tool calling is enabled by default. Fully remove or comment out the `PROVIDER_DISABLE_NATIVE_TOOL_CALLING` environment variable (or omit a provider from the list) to use native tool calling.
 
 
 ## Automatic Tool Call Approval

--- a/pages/features/chat-modes.mdx
+++ b/pages/features/chat-modes.mdx
@@ -22,7 +22,7 @@ AnythingLLM offers multiple ways to chat with your documents. Let's understand w
 
 - Will automatically use available agent-skills, tools, and MCPs to answer your questions
 - This feature is fully dependent on the capabilities of your LLM provider and model to call tools natively.
-- Most providers do not expose tool calling capabilities to the public API, so you may need to set the [`PROVIDER_SUPPORTS_NATIVE_TOOL_CALLING`](/configuration#native-tool-calling-for-llm-providers) environment variable have a always-on agent experience.
+- Native tool calling is enabled by default for providers that support it, giving you an always-on agent experience. If a provider's native tool calling misbehaves, you can fall back to prompt-based tool calling with the [`PROVIDER_DISABLE_NATIVE_TOOL_CALLING`](/configuration#native-tool-calling-for-llm-providers) environment variable.
 
 _if you see the "@" symbol in your prompt input you will need to use `@agent` to start an agentic chat session. If it is not there, you are using agentic chat mode._
 


### PR DESCRIPTION
Updates the docs to reflect [Mintplex-Labs/anything-llm#5751](https://github.com/Mintplex-Labs/anything-llm/pull/5751), which flips native tool calling from opt-in to opt-out.

## What changed

**`pages/configuration.mdx`** — Rewrote the "Native Tool Calling for LLM Providers" section:
- Native tool calling is now **enabled by default** for providers that support it.
- Replaced `PROVIDER_SUPPORTS_NATIVE_TOOL_CALLING` with the new `PROVIDER_DISABLE_NATIVE_TOOL_CALLING` variable, which forces listed providers back to prompt-based (UnTooled) tool calling.
- Swapped the Enable/Disable subsections to match the inverted behavior.
- Corrected the Local AI provider tag from `local-ai` → `localai` to match the app code, and listed each provider's exact tag.
- Added a note that automatic-mode workspaces now run the agent without the `@agent` prefix by default, and that disabling restores explicit invocation.

**`pages/features/chat-modes.mdx`** — Updated the reference to the old env var to describe the new default-on behavior and point to `PROVIDER_DISABLE_NATIVE_TOOL_CALLING` as the fallback.

Changelog files were left untouched as historical records of past releases.