### PR TITLE
Docs: Create Scheduled Jobs agent skill

### DIFF
--- a/pages/agent/usage/_meta.json
+++ b/pages/agent/usage/_meta.json
@@ -124,5 +124,14 @@
       "pagination": true,
       "toc": true
     }
+  },
+  "create-scheduled-job": {
+    "title": "Create Scheduled Jobs",
+    "theme": {
+      "breadcrumb": true,
+      "footer": true,
+      "pagination": true,
+      "toc": true
+    }
   }
 }

--- a/pages/agent/usage/create-scheduled-job.mdx
+++ b/pages/agent/usage/create-scheduled-job.mdx
@@ -1,0 +1,69 @@
+---
+title: "Create Scheduled Jobs"
+description: "Use the Create Scheduled Jobs agent skill to set up recurring agent tasks conversationally."
+---
+
+import { Callout } from "nextra/components";
+import Image from "next/image";
+
+## Create Scheduled Jobs
+
+<Callout type="warning" emoji="️💡">
+  This agent skill is **only available in single-user mode**. Self-hosted
+  instances running in multi-user mode will not see this skill, and it is hidden
+  from the agent in those environments.
+</Callout>
+
+The **Create Scheduled Jobs** agent skill lets you set up a [Scheduled Job](/scheduled-jobs/overview)
+just by talking to the agent — no need to open **Settings > Scheduled Jobs** and fill out
+the form yourself. Describe what you want done and when, and the agent will create the job
+for you.
+
+This is the conversational counterpart to the [Scheduled Jobs](/scheduled-jobs/overview)
+settings page. Anything you can build by hand in that form — a name, a prompt, a schedule, and
+a set of allowed tools — the agent can create from a single natural-language request.
+
+## Enabling the skill
+
+Create Scheduled Jobs is an **opt-in default agent skill**. To turn it on:
+
+1. Open **Settings** > **Agent Skills**
+2. Find **Create Scheduled Jobs** in the skills list and enable it.
+
+Once enabled, the skill is available to the agent in any workspace on that instance.
+
+## How to use it
+
+Just ask the agent to schedule something, in plain language. Be clear about three things:
+
+- **What** the job should do (the task/prompt)
+- **When** it should run (the frequency and time)
+- **Which tools** it needs, if any
+
+**Example:** `@agent every weekday at 9am, summarize my inbox and email me a digest`
+
+**Example:** `@agent schedule a job to check anythingllm.com every Monday at 8am and note anything new`
+
+**Example:** `@agent create a job that runs every 6 hours and pulls the latest numbers into a report`
+
+When you describe a time, give it in **your local time**. AnythingLLM converts your local
+schedule to the correct UTC cron expression deterministically, so you don't need to do any
+timezone math — "9am" means 9am where you are.
+
+The agent will only let a job use tools that are actually configured and ready on your instance,
+mirroring the tool list you'd see in the manual job form. You can also create a job with no
+tools at all, in which case it runs against the LLM alone.
+
+## After the job is created
+
+When the agent successfully creates a job, it returns a clickable card in the conversation.
+Click it to jump straight to that job in **Settings > Scheduled Jobs**, where you can review,
+edit the prompt or schedule, run it now, or disable it.
+
+<Callout type="info" emoji="️💡">
+  New jobs are **enabled by default** as soon as they're created and will fire
+  on their next scheduled time. See [Creating Your First
+  Job](/scheduled-jobs/getting-started) for everything you can configure, and
+  [Viewing Runs & Results](/scheduled-jobs/viewing-runs) for how to review what
+  each run produced.
+</Callout>

--- a/pages/agent/usage/overview.mdx
+++ b/pages/agent/usage/overview.mdx
@@ -14,6 +14,7 @@ import {
   BoxIcon,
   Database,
   FolderTreeIcon,
+  LightningIcon,
 } from "/components/icons";
 import Image from "next/image";
 
@@ -96,6 +97,11 @@ When you mention the agent, you will see a popup with the tools enabled for the 
     icon={<FolderTreeIcon />}
     title="File System Agent"
     href="/agent/usage/file-system-agent"
+  />
+  <Card
+    icon={<LightningIcon />}
+    title="Create Scheduled Jobs"
+    href="/agent/usage/create-scheduled-job"
   />
 </Cards>
 

--- a/pages/scheduled-jobs/getting-started.mdx
+++ b/pages/scheduled-jobs/getting-started.mdx
@@ -10,6 +10,12 @@ import Image from "next/image";
 
 This page walks through creating a scheduled job from scratch. Everything is done from **Settings > Scheduled Jobs**.
 
+<Callout type="info" emoji="💡">
+  Prefer to just ask? You can also create a job by talking to the agent with the
+  [**Create Scheduled Jobs** agent skill](/agent/usage/create-scheduled-job) — describe the task
+  and schedule in plain language and the agent fills out this form for you.
+</Callout>
+
 ## 1. Open the Scheduled Jobs page
 
 Click the **wrench icon** to open Settings, expand the **Tools** section in the sidebar, and click **Scheduled Jobs**.

--- a/pages/scheduled-jobs/overview.mdx
+++ b/pages/scheduled-jobs/overview.mdx
@@ -49,6 +49,15 @@ Open **Settings** and look for **Scheduled Jobs** in the sidebar. From there you
 - Trigger a job immediately with **Run Now**
 - Open a job's run history to see past results
 
+## Creating jobs conversationally
+
+You don't have to use the settings form to create a job. If you enable the
+[**Create Scheduled Jobs** agent skill](/agent/usage/create-scheduled-job), you can ask the agent
+to set up a job for you in plain language — for example, _"@agent every weekday at 9am, summarize
+my inbox and email me a digest"_. The agent builds the job (name, prompt, schedule, and tools) and
+hands you a clickable card to review or edit it. Like the rest of Scheduled Jobs, this skill is
+**single-user mode only**.
+
 ## Next steps
 
 Start with [Creating Your First Job](/scheduled-jobs/getting-started), then dig into [Scheduling & The Cron Builder](/scheduled-jobs/scheduling) for everything you can do with cron expressions. When you're ready to look at results, see [Viewing Runs & Results](/scheduled-jobs/viewing-runs).


### PR DESCRIPTION
Documents the new `create-scheduled-job` agent skill from [anything-llm#5916](https://github.com/Mintplex-Labs/anything-llm/pull/5916), which lets users create Scheduled Jobs conversationally.

## Changes
- **New page** `agent/usage/create-scheduled-job.mdx` — enabling the skill, conversational usage with examples, local-time→UTC handling, tool validation, single-user-mode constraint, and the clickable result card.
- Wired into the agent skills section: `agent/usage/_meta.json` + a card on `agent/usage/overview.mdx`.
- Cross-linked from the Scheduled Jobs section: a "Creating jobs conversationally" subsection in `scheduled-jobs/overview.mdx` and a callout in `scheduled-jobs/getting-started.mdx`.
