### PR TITLE
docs: add Neon AI Gateway setup guide

### DIFF
--- a/pages/setup/llm-configuration/cloud/_meta.json
+++ b/pages/setup/llm-configuration/cloud/_meta.json
@@ -71,6 +71,15 @@
       "toc": true
     }
   },
+  "neon-ai-gateway": {
+    "title": "Neon AI Gateway",
+    "theme": {
+      "breadcrumb": true,
+      "footer": true,
+      "pagination": true,
+      "toc": true
+    }
+  },
   "openai": {
     "title": "OpenAI",
     "theme": {

--- a/pages/setup/llm-configuration/cloud/neon-ai-gateway.mdx
+++ b/pages/setup/llm-configuration/cloud/neon-ai-gateway.mdx
@@ -1,0 +1,84 @@
+---
+title: "Neon AI Gateway"
+description: "Connect AnythingLLM to Neon AI Gateway, an OpenAI-compatible inference gateway built into Neon, using the Generic OpenAI provider."
+---
+
+import { Callout } from "nextra/components";
+
+# Neon AI Gateway
+
+[Neon AI Gateway](https://neon.com/docs/ai-gateway/overview) is an OpenAI-compatible inference gateway built into Neon. One Neon credential gives you access to models from OpenAI, Google, Meta, Databricks, and Alibaba, so you do not need a separate account with each provider.
+
+AnythingLLM does not have a dedicated Neon provider. Neon implements the OpenAI Chat Completions API, so you connect it through the [Generic OpenAI](/setup/llm-configuration/cloud/openai-generic) provider.
+
+<Callout type="info" emoji="️💡">
+  **Beta, paid plans, single region**
+
+  Neon AI Gateway is in beta. It requires a paid Neon plan and is only available in the AWS US East (Ohio) region (`aws-us-east-2`), so the Neon project you use must be created there.
+</Callout>
+
+## Prerequisites
+
+- A Neon project on a paid plan in the `aws-us-east-2` region.
+- AnythingLLM installed and running, either the [Desktop application](https://anythingllm.com/download) or a [Docker deployment](https://github.com/Mintplex-Labs/anything-llm).
+
+## Step 1: Create a Neon credential
+
+In the Neon Console, select your branch, click **Credentials** under **APP BACKEND**, then click **Create credential** and check **ai_gateway:invoke**. Copy the credential before closing the dialog, because Neon shows it only once. It begins with `nt_live_`.
+
+You can also create one with the Neon API:
+
+```bash
+curl -X POST "https://console.neon.tech/api/v2/projects/{project_id}/branches/{branch_id}/credentials" \
+  -H "Authorization: Bearer $NEON_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"scopes": ["ai_gateway:invoke"], "principal_type": "user"}'
+```
+
+See [AI Gateway authentication](https://neon.com/docs/ai-gateway/authentication) for scopes, branch binding, and rotation.
+
+## Step 2: Find your branch host
+
+Every Neon branch has its own gateway host, so there is no single URL that applies to a whole account. The Neon Console shows the host for a branch on the AI Gateway page as `NEON_AI_GATEWAY_BASE_URL`. It follows this format:
+
+```
+br-<name>-api.ai.<cell>.<region>.aws.neon.tech
+```
+
+This is different from your database connection string.
+
+## Step 3: Configure the Generic OpenAI provider
+
+1. Launch AnythingLLM, go to **Settings**, and open **LLM Preference**.
+2. In the LLM provider search box, type "Generic OpenAI" and select it.
+3. Fill in the connection details:
+   - **Base URL**: your branch host with `/v1` appended, for example `https://br-winter-pond-aptw82ef-api.ai.c-2.us-east-2.aws.neon.tech/v1`
+   - **API Key**: the Neon credential from step 1
+   - **Selected Model**: a model ID from the Neon catalog, for example `gpt-5-mini`
+   - **Model context window**: the context window of the model you chose, for example 400000 for `gpt-5-mini`
+   - **Max Tokens**: set according to your needs, for example 1024 or 2048
+
+Neon serves chat completions at `/v1/chat/completions`, so the Base URL must end in `/v1`.
+
+After you enter the Base URL and API Key, AnythingLLM calls `GET /v1/models` on your branch and turns **Selected Model** into a dropdown of what that branch can serve. If the call fails, the field stays a text box and you type the model ID yourself.
+
+## Step 4: Test the integration
+
+Save the configuration, then open a workspace and send a test message. If the request fails with `401`, the credential is missing or invalid. A `403` means the credential lacks the `ai_gateway:invoke` scope or does not cover the branch you are calling.
+
+## Choosing a model
+
+Use short model IDs such as `gpt-5-mini`, `gemini-3-flash`, or `qwen3-next-80b-a3b-instruct`. The branch itself lists what it can serve:
+
+```bash
+curl "$NEON_AI_GATEWAY_BASE_URL/v1/models" \
+  -H "Authorization: Bearer $NEON_AI_GATEWAY_TOKEN"
+```
+
+The [Neon model catalog](https://neon.com/docs/ai-gateway/models) lists context windows and pricing for each model. You can also browse them on [Models.dev](https://models.dev/providers/neon/).
+
+<Callout type="warning" emoji="️⚠️">
+  **Response shape varies by model**
+
+  For most models the assistant message content is a plain string. A few models, including `gemini-3-5-flash`, `gemini-3-1-pro`, `gpt-oss-120b`, and `qwen35-122b-a10b`, return an array of typed content blocks instead. If a model renders as empty output in AnythingLLM, try one that returns plain text. See [Which endpoint to use](https://neon.com/docs/ai-gateway/models#which-endpoint-to-use) in the Neon docs.
+</Callout>


### PR DESCRIPTION
### Pull Request Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style

### Relevant Issues

None. I did not file an issue first because this is a self-contained new page, but happy to open one if you would rather track it that way.

### What is in this change?

A new page, `pages/setup/llm-configuration/cloud/neon-ai-gateway.mdx`, documenting how to connect AnythingLLM to [Neon AI Gateway](https://neon.com/docs/ai-gateway/overview), plus the matching `_meta.json` entry so it lands in the Cloud LLM sidebar between Mistral AI and OpenAI.

Neon AI Gateway is an OpenAI-compatible inference gateway built into Neon. It is not a new AnythingLLM provider and the page never implies otherwise. There is no Neon entry in AnythingLLM's provider list, so the guide routes readers through the existing **Generic OpenAI** provider and links to that page. This is the same approach `truefoundry.mdx` already takes for a third-party gateway.

The page walks through:

- Creating a Neon credential with the `ai_gateway:invoke` scope, in the Console or through the Neon API
- Finding the branch gateway host, since Neon gives each branch its own host instead of one URL per account
- Filling in Generic OpenAI: **Base URL** with `/v1` appended, **API Key**, **Selected Model**, **Model context window**, **Max Tokens**
- Testing the connection, and what `401` and `403` mean
- Picking a model, with the `GET /v1/models` call and a warning about the models that return content blocks rather than a plain string

I read the field labels off the current `GenericOpenAiOptions` component in `Mintplex-Labs/anything-llm` instead of copying them from a sibling page. Two things came out of that:

- The model field is labeled **Selected Model**, not "Chat Model Name". Since #5746 it turns into a dropdown once Base URL and API Key are set, because AnythingLLM calls `GET /v1/models` and falls back to free text if that fails. Neon serves that endpoint, so the dropdown does populate, and the page says so.
- The context field is labeled **Model context window**. `truefoundry.mdx` calls it "Token Context Window", which does not match the component. I left that page untouched, but you may want to fix it separately.

I did not add a card to `setup/llm-configuration/overview.mdx`. Those cards need a header image and TrueFoundry does not have one either.

### Additional Information

Every claim on the page comes from Neon's official docs, re-checked while writing it:

- [Overview](https://neon.com/docs/ai-gateway/overview) for beta status, the paid-plan requirement, and the `aws-us-east-2` restriction
- [Quickstart](https://neon.com/docs/ai-gateway/get-started) for the credential flow and the branch host format
- [Authentication](https://neon.com/docs/ai-gateway/authentication) for the `ai_gateway:invoke` scope and branch binding
- [Models](https://neon.com/docs/ai-gateway/models) for model IDs, context windows, `GET /v1/models`, and the content-shape warning
- [Troubleshooting](https://neon.com/docs/ai-gateway/troubleshooting) for what `401` and `403` mean

Two caveats worth knowing:

- Neon is rolling frontier models out gradually, so someone on a brand new project may not have `gpt-5-mini` available yet. The `GET /v1/models` snippet is there so they can list what their own branch serves.
- No screenshots. Neighboring pages use images under `public/images/`, but I did not want to add binary assets or illustrate a UI I cannot capture against a paid Neon project. Glad to add them if you would like the page to match its neighbors.

### Validations

- [x] Ensured updated documentation pass spell check
- [x] Updated or added relevant links as needed
- [x] Reviewed the changes for clarity and accuracy
- [x] Successfully ran the code locally without encountering errors

Details on those, including what I could not run:

- `next build` finishes clean and prerenders all 210 static pages, the new route among them. No MDX or link errors.
- I checked the generated HTML: the sidebar renders "Neon AI Gateway" in the expected slot, both callouts render as prose rather than code blocks, and the page has exactly the three code blocks it should.
- `_meta.json` parses, and every key in it still maps to a file that exists.
- All six external links return 200, and the internal link to `/setup/llm-configuration/cloud/openai-generic` resolves.
- Spell check via `cspell` flags only `qwen`, which is part of the model IDs `qwen3-next-80b-a3b-instruct` and `qwen35-122b-a10b` as Neon publishes them.
- I could not run `yarn lint`. Corepack cannot fetch yarn through my network, so I installed dependencies with npm. Prettier does report formatting differences on my two files, but it reports the same on the untouched upstream `_meta.json` and `truefoundry.mdx`, so I matched the surrounding files rather than reformat and add noise to the diff. Say the word if you would like it prettier-formatted anyway.
