### PR TITLE
docs: explain Desktop and Docker port conflict

### DIFF
--- a/pages/desktop-assistant/introduction.mdx
+++ b/pages/desktop-assistant/introduction.mdx
@@ -56,16 +56,16 @@ Any chats, agentic tasks, or MCPs are processed using your LLM provider and mode
 
 The default shortcut to open the Desktop Assistant is `CMD+/` (MacOS) or `CTRL+/` (Windows/Linux).
 
-### Why is the Desktop Assistant unresponsive while AnythingLLM Docker is running?
+### Why is the Desktop application unresponsive while AnythingLLM Docker is running?
 
 <Callout type="warning" emoji="⚠️">
   AnythingLLM Desktop and the default AnythingLLM Docker setup both use port
-  `3001` on your computer. Running both at the same time can cause a port
-  conflict that prevents the Desktop Assistant from accepting text input or
+  `3001` by default on your computer. Running both at the same time can sometimes cause a port
+  conflict that prevents the Desktop application from accepting text input or
   opening its menu.
 </Callout>
 
-Stop the AnythingLLM Docker container before using the Desktop Assistant. If you
+Stop the AnythingLLM Docker container before using the Desktop application. If you
 need both running at the same time, map Docker to another available host port.
 For example, change the port mapping in the
 [local Docker run command](/installation-docker/local-docker#run-the-image) from

--- a/pages/desktop-assistant/introduction.mdx
+++ b/pages/desktop-assistant/introduction.mdx
@@ -56,22 +56,6 @@ Any chats, agentic tasks, or MCPs are processed using your LLM provider and mode
 
 The default shortcut to open the Desktop Assistant is `CMD+/` (MacOS) or `CTRL+/` (Windows/Linux).
 
-### Why is the Desktop application unresponsive while AnythingLLM Docker is running?
-
-<Callout type="warning" emoji="⚠️">
-  AnythingLLM Desktop and the default AnythingLLM Docker setup both use port
-  `3001` by default on your computer. Running both at the same time can sometimes cause a port
-  conflict that prevents the Desktop application from accepting text input or
-  opening its menu.
-</Callout>
-
-Stop the AnythingLLM Docker container before using the Desktop application. If you
-need both running at the same time, map Docker to another available host port.
-For example, change the port mapping in the
-[local Docker run command](/installation-docker/local-docker#run-the-image) from
-`-p 3001:3001` to `-p 3002:3001`, then open the Docker instance at
-`http://localhost:3002`.
-
 ### What if I want to change the shortcut?
 
 You can change the shortcut by going to the main AnythingLLM menu and clicking on "Settings" > "Desktop Assistant". Here you can change the shortcut to your liking.

--- a/pages/desktop-assistant/introduction.mdx
+++ b/pages/desktop-assistant/introduction.mdx
@@ -56,6 +56,22 @@ Any chats, agentic tasks, or MCPs are processed using your LLM provider and mode
 
 The default shortcut to open the Desktop Assistant is `CMD+/` (MacOS) or `CTRL+/` (Windows/Linux).
 
+### Why is the Desktop Assistant unresponsive while AnythingLLM Docker is running?
+
+<Callout type="warning" emoji="⚠️">
+  AnythingLLM Desktop and the default AnythingLLM Docker setup both use port
+  `3001` on your computer. Running both at the same time can cause a port
+  conflict that prevents the Desktop Assistant from accepting text input or
+  opening its menu.
+</Callout>
+
+Stop the AnythingLLM Docker container before using the Desktop Assistant. If you
+need both running at the same time, map Docker to another available host port.
+For example, change the port mapping in the
+[local Docker run command](/installation-docker/local-docker#run-the-image) from
+`-p 3001:3001` to `-p 3002:3001`, then open the Docker instance at
+`http://localhost:3002`.
+
 ### What if I want to change the shortcut?
 
 You can change the shortcut by going to the main AnythingLLM menu and clicking on "Settings" > "Desktop Assistant". Here you can change the shortcut to your liking.

--- a/pages/installation-desktop/debug.mdx
+++ b/pages/installation-desktop/debug.mdx
@@ -3,7 +3,7 @@ title: "Debug"
 description: "Learn how to run AnythingLLM in debug mode"
 ---
 
-import { Cards } from "nextra/components";
+import { Callout, Cards } from "nextra/components";
 import Image from "next/image";
 
 <Image
@@ -17,6 +17,22 @@ import Image from "next/image";
 ## General Debugging
 
 If you are having issues with AnythingLLM, the first thing you should do is check the logs. You can find the logs in the `logs` folder of your AnythingLLM storage - which you can find [on your computer using this guide.](./storage.mdx#where-is-my-data-located)
+
+## Why is the Desktop application unresponsive while AnythingLLM Docker is running?
+
+<Callout type="warning" emoji="⚠️">
+  AnythingLLM Desktop and the default AnythingLLM Docker setup both use port
+  `3001` by default on your computer. Running both at the same time can sometimes cause a port
+  conflict that prevents the Desktop application from accepting text input or
+  opening its menu.
+</Callout>
+
+Stop the AnythingLLM Docker container before using the Desktop application. If you
+need both running at the same time, map Docker to another available host port.
+For example, change the port mapping in the
+[local Docker run command](/installation-docker/local-docker#run-the-image) from
+`-p 3001:3001` to `-p 3002:3001`, then open the Docker instance at
+`http://localhost:3002`.
 
 ## AnythingLLM Debug mode on MacOS
 


### PR DESCRIPTION
### Pull Request Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style

### Relevant Issues

resolves #212

### What is in this change?

- Adds a warning to the Desktop debugging guide about the port `3001` conflict with the default AnythingLLM Docker setup.
- Documents the symptoms users may encounter when both applications run simultaneously.
- Explains how to stop the Docker container or map it to a different host port.

### Additional Information

Related product issue: Mintplex-Labs/anything-llm#5045

This is a documentation-only change. The production documentation build completed successfully.

### Validations

- [x] Ensured updated documentation pass spell check
- [x] Updated or added relevant links as needed
- [x] Reviewed the changes for clarity and accuracy
- [x] Successfully ran the code locally without encountering errors