### PR TITLE
Document storage folder permission fix for Docker

### DIFF
--- a/pages/installation-docker/local-docker.mdx
+++ b/pages/installation-docker/local-docker.mdx
@@ -99,6 +99,41 @@ your CPU does not support the AVX2 instruction set, which the default vector dat
 
 See [CPU instruction set requirements](/installation-docker/system-requirements#cpu-instruction-set-requirements) for how to check and what to do about it.
 
+### Container exits with `unable to open database file`
+
+If the container starts and then immediately dies with a log that ends like this:
+
+```text
+Datasource "db": SQLite database "anythingllm.db" at "file:../storage/anythingllm.db"
+
+Error: Schema engine error:
+SQLite database error
+unable to open database file: ../storage/anythingllm.db
+```
+
+your storage folder is not writable by the container.
+
+This almost always happens on Linux when `STORAGE_LOCATION` points somewhere under a top-level folder such as `/mnt`, `/data`, `/srv`, or `/opt`. Those folders are owned by `root`, and so is anything you create inside them. AnythingLLM runs as the unprivileged `anythingllm` user (UID/GID `1000`), so it cannot write the database file into a root-owned mount.
+
+The install command in this guide uses `$HOME/anythingllm`, which your own user already owns - that is why the default path works and a custom one may not.
+
+To fix it, give the storage folder to UID/GID `1000` before starting the container:
+
+```shell copy showLineNumbers
+sudo chown -R 1000:1000 ${STORAGE_LOCATION}
+```
+
+Then remove the dead container and run the install command again.
+
+<Callout type="warning" emoji="️⚠️">
+  You will find `chmod -R 777` suggested as a fix for this in old GitHub issues.
+  It does work, but it makes your storage folder - including your database, your
+  documents, and your `.env` with any API keys in it - readable and writable by
+  every user on the machine. Use `chown` instead.
+</Callout>
+
+The published image always runs as `1000:1000`. If you build from source with `docker-compose` and have changed the `UID` and `GID` values in your `.env`, use those numbers instead.
+
 ### Cannot connect to service running on localhost!
 
 Please see [How to connect to localhost](/installation-docker/localhost) services.


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #168


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the documentation site. -->

- add a "Container exits with `unable to open database file`" entry to the Docker install FAQ, keyed on the log output users actually see
- explain that the container runs as UID/GID `1000` and cannot write to root-owned top-level mounts like `/mnt`, `/data`, `/srv`, or `/opt`, which is why the default `$HOME/anythingllm` path works and a custom one may not
- recommend `chown -R 1000:1000` rather than the `chmod -R 777` fix circulating in old issue threads, since `777` makes the database, documents, and `.env` API keys readable and writable by every user on the machine
- note that the published image always runs as `1000:1000` and that the `.env` `UID`/`GID` values only apply to the `docker-compose` build path

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

Related product issues: Mintplex-Labs/anything-llm#1996 and Mintplex-Labs/anything-llm#2294.

### Validations

<!-- All of the applicable items should be checked. -->

- [x] Ensured updated documentation pass spell check
- [x] Updated or added relevant links as needed
- [x] Reviewed the changes for clarity and accuracy
- [x] Successfully ran the code locally without encountering errors
