### PR TITLE
feat: add Text to Speech (TTS) feature page

### DIFF
--- a/pages/features/_meta.json
+++ b/pages/features/_meta.json
@@ -126,7 +126,7 @@
     }
   },
   "transcription-models": {
-    "title": "Transcription Models",
+    "title": "Speech to Text (STT)",
     "theme": {
       "breadcrumb": true,
       "footer": true,

--- a/pages/features/_meta.json
+++ b/pages/features/_meta.json
@@ -124,7 +124,8 @@
       "pagination": true,
       "toc": true
     }
-  },  "transcription-models": {
+  },
+  "transcription-models": {
     "title": "Transcription Models",
     "theme": {
       "breadcrumb": true,

--- a/pages/features/_meta.json
+++ b/pages/features/_meta.json
@@ -116,7 +116,15 @@
       "toc": true
     }
   },
-  "transcription-models": {
+  "text-to-speech": {
+    "title": "Text to Speech (TTS)",
+    "theme": {
+      "breadcrumb": true,
+      "footer": true,
+      "pagination": true,
+      "toc": true
+    }
+  },  "transcription-models": {
     "title": "Transcription Models",
     "theme": {
       "breadcrumb": true,

--- a/pages/features/text-to-speech.mdx
+++ b/pages/features/text-to-speech.mdx
@@ -1,0 +1,102 @@
+---
+title: "Text to Speech (TTS)"
+description: "AnythingLLM supports multiple text to speech providers so chat responses can be read out loud."
+---
+
+# Text to Speech (TTS)
+
+AnythingLLM supports multiple text to speech providers so chat responses can be read out loud. Once a provider is configured, click the speaker icon under any chat response to hear it spoken.
+
+## Selecting a TTS Provider
+
+Open **Settings** and select **Voice & Speech**. Under **Text-to-speech Preference**, choose a provider from the **Provider** menu, fill in its settings, and click **Save changes**.
+
+The default provider is **System native**, which works with no configuration at all.
+
+## Supported TTS Providers
+
+### Local TTS Providers
+
+These run on your device and require no API key.
+
+#### System native
+
+Uses your browser's built in speech synthesis, if supported. Nothing is sent to any external service. Voice quality depends on your browser and operating system.
+
+#### PiperTTS
+
+Runs open source Piper voice models locally in your browser. The voice model is downloaded once, and all audio is generated privately on your device.
+
+### Self Hosted TTS Providers
+
+#### Kokoro
+
+Connects to a self hosted kokoro-fastapi server for high quality open source voices. Set the server URL (for example `http://localhost:8880/v1`), an optional API key if your server requires one, and a voice such as `af_bella`.
+
+### Cloud TTS Providers
+
+#### OpenAI
+
+Uses [OpenAI's](https://platform.openai.com/) hosted text to speech voices. Requires an OpenAI API key and a voice selection such as `nova`.
+
+#### ElevenLabs
+
+Uses [ElevenLabs](https://elevenlabs.io/) voices and technology. Requires an ElevenLabs API key, and you can choose from the voices available to your ElevenLabs account.
+
+### Any OpenAI Compatible TTS Service
+
+The **OpenAI Compatible** provider connects AnythingLLM to any service that implements the OpenAI speech API (`POST /v1/audio/speech`), whether it runs on your own network or is a hosted API. It takes four settings:
+
+- **Base URL**: the root of the service, including the version path, for example `https://api.openai.com/v1`
+- **API Key**: optional, only needed if the service requires one
+- **TTS Model**: the `model` parameter sent with each request
+- **Voice Model**: the voice identifier sent with each request
+
+#### Worked example
+
+Using [Gandr](https://gandr.ai), an OpenAI compatible text to speech API, as the example service:
+
+| Setting     | Value                                                        |
+| ----------- | ------------------------------------------------------------ |
+| Base URL    | `https://tts.gandr.ai/v1`                                    |
+| API Key     | your Gandr API key, created at [gandr.ai](https://gandr.ai)  |
+| TTS Model   | `tts-1`                                                      |
+| Voice Model | `gandr-mia`                                                  |
+
+Gandr's other voices are `gandr-ava`, `gandr-jenny`, `gandr-dane`, `gandr-leo`, and `gandr-lewis`. Save changes, then click the speaker icon on any chat response to hear it.
+
+The same four settings work for any other OpenAI compatible speech endpoint, hosted or self hosted.
+
+## Environment Variables
+
+If you deploy AnythingLLM with Docker or bare metal and prefer to configure TTS through environment variables, these are the supported keys (from `docker/.env.example`):
+
+```shell
+# System native (default)
+TTS_PROVIDER="native"
+
+# OpenAI
+TTS_PROVIDER="openai"
+TTS_OPEN_AI_KEY=sk-example
+TTS_OPEN_AI_VOICE_MODEL=nova
+
+# ElevenLabs
+TTS_PROVIDER="elevenlabs"
+TTS_ELEVEN_LABS_KEY=
+TTS_ELEVEN_LABS_VOICE_MODEL=21m00Tcm4TlvDq8ikWAM
+
+# Kokoro
+TTS_PROVIDER="kokoro"
+TTS_KOKORO_ENDPOINT="http://host.docker.internal:8880/v1"
+TTS_KOKORO_KEY=
+TTS_KOKORO_VOICE_MODEL=af_bella
+
+# Any OpenAI compatible service
+TTS_PROVIDER="generic-openai"
+TTS_OPEN_AI_COMPATIBLE_ENDPOINT="https://api.openai.com/v1"
+TTS_OPEN_AI_COMPATIBLE_KEY=sk-example
+TTS_OPEN_AI_COMPATIBLE_MODEL=tts-1
+TTS_OPEN_AI_COMPATIBLE_VOICE_MODEL=nova
+```
+
+Set only one `TTS_PROVIDER` value. **System native** and **PiperTTS** run in the browser, so PiperTTS is configured from the UI rather than through server variables.

--- a/pages/features/text-to-speech.mdx
+++ b/pages/features/text-to-speech.mdx
@@ -52,21 +52,6 @@ The **OpenAI Compatible** provider connects AnythingLLM to any service that impl
 - **TTS Model**: the `model` parameter sent with each request
 - **Voice Model**: the voice identifier sent with each request
 
-#### Worked example
-
-Using [Gandr](https://gandr.ai), an OpenAI compatible text to speech API, as the example service:
-
-| Setting     | Value                                                        |
-| ----------- | ------------------------------------------------------------ |
-| Base URL    | `https://tts.gandr.ai/v1`                                    |
-| API Key     | your Gandr API key, created at [gandr.ai](https://gandr.ai)  |
-| TTS Model   | `tts-1`                                                      |
-| Voice Model | `gandr-mia`                                                  |
-
-Gandr's other voices are `gandr-ava`, `gandr-jenny`, `gandr-dane`, `gandr-leo`, and `gandr-lewis`. Save changes, then click the speaker icon on any chat response to hear it.
-
-The same four settings work for any other OpenAI compatible speech endpoint, hosted or self hosted.
-
 ## Environment Variables
 
 If you deploy AnythingLLM with Docker or bare metal and prefer to configure TTS through environment variables, these are the supported keys (from `docker/.env.example`):


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style

### Relevant Issues

None

### What is in this change?

The docs currently cover speech to text (Transcription Models) but have no page for text to speech, even though the app ships six TTS providers. This PR adds that page.

- New page `pages/features/text-to-speech.mdx` documenting every built in TTS provider (System native, OpenAI, ElevenLabs, PiperTTS, Kokoro, and OpenAI Compatible), how to reach the setting (Settings, Voice & Speech, Text-to-speech Preference), a worked example for the OpenAI Compatible provider, and the matching environment variables from `docker/.env.example`.
- Registers the page in `pages/features/_meta.json` directly after Transcription Models.

Provider names, setting labels, defaults, and environment variable names were taken from the app source (`server/utils/TextToSpeech/` and `frontend/src/pages/GeneralSettings/AudioPreference/tts.jsx`) so the page matches what users actually see.

### Additional Information

The page is plain MDX with no imports and no new assets, so nothing else on the site is touched. I left out a header image rather than add placeholder art; happy to add one matching the `/images/features/<page>/header-image.png` convention in a follow up, or adjust anything else you would like.

The worked example for the OpenAI Compatible provider uses Gandr, a text to speech API I work on. The example is deliberately generic: any OpenAI compatible speech endpoint works with the same four settings, and I am glad to swap the example service if you prefer.

### Validations

<!-- All of the applicable items should be checked. -->

- [x] Ensured updated documentation pass spell check
- [x] Updated or added relevant links as needed
- [x] Reviewed the changes for clarity and accuracy
- [ ] Successfully ran the code locally without encountering errors

Disclosure: I work on Gandr.